### PR TITLE
Add function to insert multiple rows in one statement

### DIFF
--- a/processor/src/main/kotlin/com/github/darkxanter/kesp/processor/generator/generateCrudRepository.kt
+++ b/processor/src/main/kotlin/com/github/darkxanter/kesp/processor/generator/generateCrudRepository.kt
@@ -123,6 +123,17 @@ internal fun FileSpec.Builder.generateCrudRepository(tableDefinition: TableDefin
                         addStatement("$tableName.${tableDefinition.insertDtoFunName}(dto)")
                     }
                 }
+
+                addFunction("createMultiple") {
+                    addParameter("dtos", Iterable::class.asClassName().parameterizedBy(tableDefinition.createInterfaceClassName))
+                    tableDefinition.primaryKey.singleOrNull()?.let {
+                        returns(List::class.asClassName().parameterizedBy(it.className))
+                        addReturn()
+                    }
+                    transactionBlock {
+                        addStatement("$tableName.${tableDefinition.batchInsertDtoFunName}(dtos)")
+                    }
+                }
             }
 
             if (tableDefinition.hasUpdateFun) {

--- a/processor/src/main/kotlin/com/github/darkxanter/kesp/processor/generator/model/TableDefinition.kt
+++ b/processor/src/main/kotlin/com/github/darkxanter/kesp/processor/generator/model/TableDefinition.kt
@@ -32,6 +32,7 @@ internal data class TableDefinition(
     val fullDtoClassName = declaration.toClassName("${tableName}FullDto")
     val repositoryClassName = declaration.toClassName("${tableName}Repository")
 
+    val batchInsertDtoFunName = "batchInsertDtos"
     val insertDtoFunName = "insertDto"
     val updateDtoFunName = "updateDto"
     val toDtoFunName = "to${fullDtoClassName.simpleName}"

--- a/processor/src/test/kotlin/com/github/darkxanter/kesp/processor/SimpleTest.kt
+++ b/processor/src/test/kotlin/com/github/darkxanter/kesp/processor/SimpleTest.kt
@@ -108,9 +108,15 @@ class SimpleTest : BaseKspTest() {
             import kotlin.collections.List
             import org.jetbrains.exposed.sql.Alias
             import org.jetbrains.exposed.sql.ResultRow
+            import org.jetbrains.exposed.sql.batchInsert
             import org.jetbrains.exposed.sql.insertAndGetId
             import org.jetbrains.exposed.sql.statements.UpdateBuilder
             import org.jetbrains.exposed.sql.update
+
+            public fun UserTable.batchInsertDtos(dtos: Iterable<UserTableCreate>): List<Long> =
+                UserTable.batchInsert(dtos) {
+              this.fromDto(it)
+            }.map { it[UserTable.id].value }
 
             public fun UserTable.insertDto(dto: UserTableCreate): Long = UserTable.insertAndGetId {
               it.fromDto(dto)
@@ -308,6 +314,7 @@ class SimpleTest : BaseKspTest() {
                 import kotlin.Long
                 import kotlin.Suppress
                 import kotlin.Unit
+                import kotlin.collections.Iterable
                 import kotlin.collections.List
                 import org.jetbrains.exposed.sql.ISqlExpressionBuilder
                 import org.jetbrains.exposed.sql.Op
@@ -349,6 +356,10 @@ class SimpleTest : BaseKspTest() {
 
                   public fun create(dto: UserTableCreate): Long = transaction {
                     UserTable.insertDto(dto)
+                  }
+
+                  public fun createMultiple(dtos: Iterable<UserTableCreate>): List<Long> = transaction {
+                    UserTable.batchInsertDtos(dtos)
                   }
 
                   public fun update(id: Long, dto: UserTableCreate): Int = transaction {
@@ -412,6 +423,7 @@ class SimpleTest : BaseKspTest() {
         repository shouldHaveFunction "findOne"
         repository shouldHaveFunction "findById"
         repository shouldHaveFunction "create"
+        repository shouldHaveFunction "createMultiple"
         repository shouldHaveFunction "update"
         repository shouldHaveFunction "deleteById"
         repository shouldHaveFunction "delete"


### PR DESCRIPTION
This commit adds a new function named createMultiple which, when generated, uses the batchInsert function from Exposed to add multiple rows in a single statement.